### PR TITLE
Fixed a bug that was causing requests for an access token to fail when u...

### DIFF
--- a/src/LucaDegasperi/OAuth2Server/Proxies/AuthorizationServerProxy.php
+++ b/src/LucaDegasperi/OAuth2Server/Proxies/AuthorizationServerProxy.php
@@ -5,6 +5,7 @@ use League\OAuth2\Server\Util\RedirectUri;
 use League\OAuth2\Server\Exception\ClientException;
 use Exception;
 use Response;
+use Input;
 
 class AuthorizationServerProxy
 {
@@ -70,8 +71,11 @@ class AuthorizationServerProxy
     {
         try {
 
+            // Get user input
+            $input = Input::all();
+
             // Tell the auth server to issue an access token
-            $response = $this->authServer->issueAccessToken();
+            $response = $this->authServer->issueAccessToken($input);
 
         } catch (ClientException $e) {
 


### PR DESCRIPTION
Fixed a bug that was causing requests for an access token to fail when using oauth internally. For example, I'm building an API that is being used by my application internally, but still authorising using `client_credentials`.

This bug was causing an error when trying to retrieve an access token; was telling me that required parameters.
