### PR TITLE
Fix foreign key name for oauth_client_metadata rollback

### DIFF
--- a/src/migrations/2013_08_07_183636_create_oauth_client_metadata_table.php
+++ b/src/migrations/2013_08_07_183636_create_oauth_client_metadata_table.php
@@ -38,7 +38,7 @@ class CreateOauthClientMetadataTable extends Migration
     public function down()
     {
         Schema::table('oauth_client_metadata', function ($table) {
-            $table->dropForeign('oauth_grant_scopes_client_id_foreign');
+            $table->dropForeign('oauth_client_metadata_client_id_foreign');
         });
         Schema::drop('oauth_client_metadata');
     }


### PR DESCRIPTION
Got stuck trying to migrate:reset and found this naming mismatch.

Cheers
