### PR TITLE
Fix a bug that session_id is not passed through.

### DIFF
--- a/src/LucaDegasperi/OAuth2Server/Repositories/FluentSession.php
+++ b/src/LucaDegasperi/OAuth2Server/Repositories/FluentSession.php
@@ -98,7 +98,7 @@ class FluentSession implements SessionInterface, SessionManagementInterface
     public function validateAccessToken($accessToken)
     {
         $result = DB::table('oauth_session_access_tokens')
-                    ->select('oauth_sessions.*')
+                    ->select('oauth_session_access_tokens.session_id', 'oauth_sessions.*')
                     ->join('oauth_sessions', 'oauth_session_access_tokens.session_id', '=', 'oauth_sessions.id')
                     ->where('access_token', $accessToken)
                     ->where('access_token_expires', '>=', time())


### PR DESCRIPTION
The session_id is still needed, see https://github.com/php-loep/oauth2-server/blob/develop/src/League/OAuth2/Server/Resource.php#L193 for reference.
