### PR TITLE
Allow passing of inputParams

### DIFF
--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -73,11 +73,12 @@ class Authorizer
 
     /**
      * Issue an access token if the request parameters are valid
+     * @param  array $inputParams Optional array of parsed $_POST keys
      * @return array a response object for the protocol in use
      */
-    public function issueAccessToken()
+    public function issueAccessToken($inputParams = array())
     {
-        return $this->issuer->issueAccessToken();
+        return $this->issuer->issueAccessToken($inputParams);
     }
 
     /**


### PR DESCRIPTION
This allows easier injection of custom params.

This matches the function signature of the Authorizer from the parent library so that users can pass in custom parameters that may not be loaded in the standard request.
