### PR TITLE
Correct Password Grant Callback for UserID Storage

### DIFF
--- a/src/config/oauth2.php
+++ b/src/config/oauth2.php
@@ -41,11 +41,16 @@ return [
     |
     |        // the code to run in order to verify the user's identity
     |        'callback'         => function($username, $password){
-    |
-    |            return Auth::validate([
+    |            $credentials = [
     |                'email'    => $username,
     |                'password' => $password,
-    |            ));
+    |            ];
+    |
+    |            if (Auth::once($credentials)) {
+    |                return Auth::user()->id;
+    |            } else {
+    |                return false;
+    |            }
     |        }
     |    ],
     |


### PR DESCRIPTION
This is an update to the suggested callback for password grants.

After testing I found that all of my applications were authorizing to user with id of one when using password grant.

I was looking around to figure out what was going on and found that the PasswordGrant class expects the callback to return `false` when not authorized or the user id.

Since the old callback was sending back true, Laravel's DB checker was casting this to `1` and all my requests where then showing the session's user as the user where `id` = `1`.

I'm also going to look in the wiki and update the docs for this change.
