### PR TITLE
Some fixes to the client creator command

### DIFF
--- a/src/Console/ClientCreatorCommand.php
+++ b/src/Console/ClientCreatorCommand.php
@@ -23,7 +23,7 @@ class ClientCreatorCommand extends Command
      *
      * @var string
      */
-    protected $name = 'oauth2-server:client:create';
+    protected $name = 'oauth2-server:create-client';
 
     /**
      * The console command description.


### PR DESCRIPTION
The client creator command had the name and id fields swapped when they were inserted to the database.
Also changed the command name to something more appropriate to follow convention (like auth:clear-reminders and generate:publish-templates).
