### PR TITLE
Removed old branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,6 @@
             "tests/integration/DBTestCase.php"
         ]
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.0.x-dev"
-        }
-    },
     "minimum-stability": "dev",
     "license": "MIT"
 }


### PR DESCRIPTION
The 3.x branch doesn't need this.
