### PR TITLE
[Bugfix] Fix typo in service provider

### DIFF
--- a/src/OAuth2ServerServiceProvider.php
+++ b/src/OAuth2ServerServiceProvider.php
@@ -67,7 +67,7 @@ class OAuth2ServerServiceProvider extends ServiceProvider
                           ->requireScopeParam($config['scope_param'])
                           ->setDefaultScope($config['default_scope'])
                           ->requireStateParam($config['state_param'])
-                          ->setScopeDelimeter($config['scope_delimiter'])
+                          ->setScopeDelimiter($config['scope_delimiter'])
                           ->setAccessTokenTTL($config['access_token_ttl']);
 
             // add the supported grant types to the authorization server


### PR DESCRIPTION
There is a typo in the service provider which causes a fatal error. Fixed it here.
