### PR TITLE
Update CheckAuthorizationParamsFilter.php to display a usable error, instead of Internal Server Error 500

### DIFF
--- a/src/LucaDegasperi/OAuth2Server/Filters/CheckAuthorizationParamsFilter.php
+++ b/src/LucaDegasperi/OAuth2Server/Filters/CheckAuthorizationParamsFilter.php
@@ -38,7 +38,7 @@ class CheckAuthorizationParamsFilter
             return Response::json(array(
                 'status' => 500,
                 'error' => 'internal_server_error',
-                'error_message' => 'Internal Server Error',
+                'error_message' => $e->getMessage(),
             ), 500);
         }
     }


### PR DESCRIPTION
Since all exceptions are being caught, they will not be logged.
This makes it harder to see what actually goes wrong here.

Its also possible to hide this error message behind a Config::get('app.debug');
I don't know if $e->getMessage() spills private information.