### PR TITLE
L5 - Method 'hasScope' only accepts a string as argument.

### DIFF
--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -187,7 +187,20 @@ class Authorizer
      */
     public function hasScope($scope)
     {
-        return $this->checker->getAccessToken()->hasScope($scope);
+        if(is_array($scope)) {
+            
+            foreach ($scope as $scopeId) {
+
+                if(!$this->checker->getAccessToken()->hasScope($scopeId)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        else {
+
+            return $this->checker->getAccessToken()->hasScope($scope);
+        }
     }
 
     /**


### PR DESCRIPTION
I have to modify the `hasScope` method of the `Authorizer` class to make it work with Laravel 5.
The internal `hasScope` method of the oauth server only supports scope checking with the scope id (string) not with multiple values (array).