### PR TITLE
Update FluentAccessToken.php

### DIFF
--- a/src/Storage/FluentAccessToken.php
+++ b/src/Storage/FluentAccessToken.php
@@ -27,7 +27,6 @@ class FluentAccessToken extends FluentAdapter implements AccessTokenInterface
     {
         $result = $this->getConnection()->table('oauth_access_tokens')
                 ->where('oauth_access_tokens.id', $token)
-                ->where('oauth_access_tokens.expire_time', '>=', time())
                 ->first();
 
         if (is_null($result)) {


### PR DESCRIPTION
Using Laravel 5, and master of oauth2-server-laravel.
The expire_time constraint added in get-method in FluentAccessToken class breaks support of refresh_token, and seems unnecessary, as access_token expire-check is done in the isValidRequest method in the ResourceServer class.