### PR TITLE
Moved laravel/framework to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "laravel/framework": "5.0.*",
         "league/oauth2-server": "4.1.*"
     },
     "require-dev": {
+        "laravel/framework": "5.0.*",
         "orchestra/testbench": "3.0.*",
         "phpunit/phpunit": "~4.0",
         "phpspec/phpspec": "~2.0",


### PR DESCRIPTION
@lucadegasperi I don't understand why you would want to always require ```laravel/framework```. This choice prevents us from using this great library with Lumen, simply because you cannot install both Lumen and Laravel in the same project. I've moved ```laravel/framework``` under ```require-dev``` to solve this problem.

This might also fix issue #351 (at least it fixes the composer dependency error) but I have yet to put it all together so I cannot say for sure.