### PR TITLE
Add back Laravel 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/database": "5.1.*@dev",
-        "illuminate/console": "5.1.*@dev",
-        "illuminate/contracts": "5.1.*@dev",
-        "illuminate/http": "5.1.*@dev",
-        "illuminate/support": "5.1.*@dev",
-        "illuminate/config": "5.1.*@dev",
+        "illuminate/database": "5.0.*|5.1.*",
+        "illuminate/console": "5.0.*|5.1.*",
+        "illuminate/contracts": "5.0.*|5.1.*",
+        "illuminate/http": "5.0.*|5.1.*",
+        "illuminate/support": "5.0.*|5.1.*",
+        "illuminate/config": "5.0.*|5.1.*",
         "league/oauth2-server": "4.1.*"
     },
     "require-dev": {


### PR DESCRIPTION
We should of course still support Laravel 5.0 that was removed in #379. My bad, sorry about that.