### PR TITLE
Relaxing version constraints for illuminate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/database": "5.0.*|5.1.*",
-        "illuminate/console": "5.0.*|5.1.*",
-        "illuminate/contracts": "5.0.*|5.1.*",
-        "illuminate/http": "5.0.*|5.1.*",
-        "illuminate/support": "5.0.*|5.1.*",
-        "illuminate/config": "5.0.*|5.1.*",
+        "illuminate/database": "^5.0.0",
+        "illuminate/console": "^5.0.0",
+        "illuminate/contracts": "^5.0.0",
+        "illuminate/http": "^5.0.0",
+        "illuminate/support": "^5.0.0",
+        "illuminate/config": "^5.0.0",
         "league/oauth2-server": "4.1.*"
     },
     "require-dev": {


### PR DESCRIPTION
This enables minor version bumps, so Laravel 5.0, 5.1, 5.2, etc. (But *not* 6.x.x) can be used with this package.

Also see issue #395 :smile: 