### PR TITLE
updated service provider to allow for custom-named grants via config

### DIFF
--- a/src/OAuth2ServerServiceProvider.php
+++ b/src/OAuth2ServerServiceProvider.php
@@ -85,7 +85,7 @@ class OAuth2ServerServiceProvider extends ServiceProvider
                 if (array_key_exists('refresh_token_ttl', $grantParams)) {
                     $grant->setRefreshTokenTTL($grantParams['refresh_token_ttl']);
                 }
-                $issuer->addGrantType($grant);
+                $issuer->addGrantType($grant, $grantIdentifier);
             }
 
             $checker = $app->make('League\OAuth2\Server\ResourceServer');


### PR DESCRIPTION
Because the `grant_type` parameter is public, I wanted to have config-based control over the public value - passing the `$grantIdentifier` when setting up the service provider takes care of that cleanly.