### PR TITLE
Fixed the logical operators to avoid precedence bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/lucadegasperi/oauth2-server-laravel/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/lucadegasperi/oauth2-server-laravel)
 [![Total Downloads](https://img.shields.io/packagist/dt/lucadegasperi/oauth2-server-laravel.svg?style=flat-square)](https://packagist.org/packages/lucadegasperi/oauth2-server-laravel)
 
+[![Code Climate](https://codeclimate.com/github/lucadegasperi/oauth2-server-laravel/badges/gpa.svg)](https://codeclimate.com/github/lucadegasperi/oauth2-server-laravel)
+
 [OAuth 2.0](http://tools.ietf.org/wg/oauth/draft-ietf-oauth-v2/) authorization server and resource server for the Laravel framework. Standard compliant thanks to the amazing work by [The League of Extraordinary Packages](http://www.thephpleague.com) OAuth 2.0 authorization server and resource server.
 
 The package assumes you have a good-enough knowledge of the principles behind the [OAuth 2.0 Specification](http://tools.ietf.org/html/rfc6749).

--- a/src/Filters/OAuthFilter.php
+++ b/src/Filters/OAuthFilter.php
@@ -102,7 +102,7 @@ class OAuthFilter
      */
     public function validateScopes()
     {
-        if (!empty($this->scopes) and !$this->authorizer->hasScope($this->scopes)) {
+        if (!empty($this->scopes) && !$this->authorizer->hasScope($this->scopes)) {
             throw new InvalidScopeException(implode(',', $this->scopes));
         }
     }

--- a/src/Storage/FluentClient.php
+++ b/src/Storage/FluentClient.php
@@ -92,7 +92,7 @@ class FluentClient extends FluentAdapter implements ClientInterface
                    ->where('oauth_client_endpoints.redirect_uri', $redirectUri);
         }
 
-        if ($this->limitClientsToGrants === true and ! is_null($grantType)) {
+        if ($this->limitClientsToGrants === true && ! is_null($grantType)) {
             $query = $query->join('oauth_client_grants', 'oauth_clients.id', '=', 'oauth_client_grants.client_id')
                    ->join('oauth_grants', 'oauth_grants.id', '=', 'oauth_client_grants.grant_id')
                    ->where('oauth_grants.id', $grantType);

--- a/src/Storage/FluentScope.php
+++ b/src/Storage/FluentScope.php
@@ -69,12 +69,12 @@ class FluentScope extends FluentAdapter implements ScopeInterface
                     ->select('oauth_scopes.id as id', 'oauth_scopes.description as description')
                     ->where('oauth_scopes.id', $scope);
 
-        if ($this->limitClientsToScopes === true and ! is_null($clientId)) {
+        if ($this->limitClientsToScopes === true && ! is_null($clientId)) {
             $query = $query->join('oauth_client_scopes', 'oauth_scopes.id', '=', 'oauth_client_scopes.scope_id')
                            ->where('oauth_client_scopes.client_id', $clientId);
         }
 
-        if ($this->limitScopesToGrants === true and ! is_null($grantType)) {
+        if ($this->limitScopesToGrants === true && ! is_null($grantType)) {
             $query = $query->join('oauth_grant_scopes', 'oauth_scopes.id', '=', 'oauth_grant_scopes.scope_id')
                            ->join('oauth_grants', 'oauth_grants.id', '=', 'oauth_grant_scopes.grant_id')
                            ->where('oauth_grants.id', $grantType);


### PR DESCRIPTION
I'm testing out the value of the checks in psecio-parse, so I scanned your repo and found a few issues. I updated three of the items it found. Using the words instead of the symbol versions of the logical operators can cause precedence bugs, so I updated them for you. I also added the Code Climate badge to your readme in case you'd like to see more of this kind of analysis for your code. You have a 3.69 score (out of 4), which is awesome! 