### PR TITLE
Rename AuthorizerFacade to just Authorizer

### DIFF
--- a/src/Facades/Authorizer.php
+++ b/src/Facades/Authorizer.php
@@ -13,7 +13,7 @@ namespace LucaDegasperi\OAuth2Server\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class AuthorizerFacade extends Facade
+class Authorizer extends Facade
 {
     /**
      * Get the registered name of the component


### PR DESCRIPTION
This is just a more common naming convention.