### PR TITLE
Possible fix for object type error

### DIFF
--- a/src/OAuth2ServerServiceProvider.php
+++ b/src/OAuth2ServerServiceProvider.php
@@ -98,9 +98,10 @@ class OAuth2ServerServiceProvider extends ServiceProvider
                 $grant->setAccessTokenTTL($grantParams['access_token_ttl']);
 
                 if (array_key_exists('callback', $grantParams)) {
-                    list($className, $method) = array_pad(explode('@', $grantParams['callback']), 2, 'verify');
-                    $verifier = $app->make($className);
-                    $grant->setVerifyCredentialsCallback([$verifier, $method]);
+                    // list($className, $method) = array_pad(explode('@', $grantParams['callback']), 2, 'verify');
+                    // $verifier = $app->make($className);
+                    // $grant->setVerifyCredentialsCallback([$verifier, $method]);
+                    $grant->setVerifyCredentialsCallback($grantParams['callback']);
                 }
                 if (array_key_exists('auth_token_ttl', $grantParams)) {
                     $grant->setAuthTokenTTL($grantParams['auth_token_ttl']);


### PR DESCRIPTION
This `setVerifyCredentialsCallback` in the `OAuth2ServerServiceProvider` class is not happy with the password grant passed in because of the callback function taken from the website placed in the `oauth2` config file.

Currently passing this grant type:
http://laravel.io/bin/BLwBJ

produces this error when authenticating:
http://laravel.io/bin/1y6rv

I am getting a successful authentication along with the access token with the modification made below.