### PR TITLE
Fixed #376 missing rotate_refresh_tokens param for RefreshTokenGrant

### DIFF
--- a/src/OAuth2ServerServiceProvider.php
+++ b/src/OAuth2ServerServiceProvider.php
@@ -108,6 +108,9 @@ class OAuth2ServerServiceProvider extends ServiceProvider
                 if (array_key_exists('refresh_token_ttl', $grantParams)) {
                     $grant->setRefreshTokenTTL($grantParams['refresh_token_ttl']);
                 }
+                if (array_key_exists('rotate_refresh_tokens', $grantParams)) {
+                    $grant->setRefreshTokenRotation($grantParams['rotate_refresh_tokens']);
+                }
                 $issuer->addGrantType($grant);
             }
 


### PR DESCRIPTION
but still need to fix the [thephpleague/oauth2-server v4.1.3 pull 294](https://github.com/thephpleague/oauth2-server/pull/294).
add below code to League\OAuth2\Server\Grant\RefreshTokenGrant line 189:

        } else {
            $oldRefreshToken->setAccessToken($newAccessToken);
            $oldRefreshToken->save();

            $this->server->getTokenType()->setParam('refresh_token', $oldRefreshToken->getId());
        }
