### PR TITLE
Create Grant via DI container

### DIFF
--- a/src/OAuth2ServerServiceProvider.php
+++ b/src/OAuth2ServerServiceProvider.php
@@ -94,7 +94,7 @@ class OAuth2ServerServiceProvider extends ServiceProvider
 
             // add the supported grant types to the authorization server
             foreach ($config['grant_types'] as $grantIdentifier => $grantParams) {
-                $grant = new $grantParams['class'];
+                $grant = $app->make($grantParams['class']);
                 $grant->setAccessTokenTTL($grantParams['access_token_ttl']);
 
                 if (array_key_exists('callback', $grantParams)) {


### PR DESCRIPTION
I have dependency in my PasswordGrant, injected via constructor so creating grants via "new" throws error. 

Is there any reason why not to use DI container?