### PR TITLE
Don't autoload the database migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,7 @@
     "autoload": {
         "psr-4": {
             "LucaDegasperi\\OAuth2Server\\": "src"
-        },
-        "classmap": [
-            "database"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
This will return error as "ambiguous class resolutions". This doesn't change any behavior except making the warning disappear.