### PR TITLE
[Proposal] Add Custom Grants (WIP)

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * (c) Luca Degasperi <packages@lucadegasperi.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Grant;
+
+use League\OAuth2\Server\Entity\AccessTokenEntity;
+use League\OAuth2\Server\Entity\ClientEntity;
+use League\OAuth2\Server\Entity\RefreshTokenEntity;
+use League\OAuth2\Server\Entity\SessionEntity;
+use League\OAuth2\Server\Event\ClientAuthenticationFailedEvent;
+use League\OAuth2\Server\Event\UserAuthenticationFailedEvent;
+use League\OAuth2\Server\Exception\InvalidClientException;
+use League\OAuth2\Server\Exception\InvalidCredentialsException;
+use League\OAuth2\Server\Exception\InvalidRequestException;
+use League\OAuth2\Server\Grant\AbstractGrant as Grant;
+use League\OAuth2\Server\Util\SecureKey;
+
+/**
+ * This is the abstract grant class.
+ *
+ * @author Vincent Klaiber <hello@vinkla.com>
+ */
+abstract class AbstractGrant extends Grant
+{
+    /**
+     * Response type.
+     *
+     * @var string
+     */
+    protected $responseType;
+
+    /**
+     * Access token expires in override.
+     *
+     * @var int
+     */
+    protected $accessTokenTTL;
+
+    /**
+     * Validate the data and check the credentials.
+     *
+     * @throws \League\OAuth2\Server\Exception\InvalidRequestException
+     *
+     * @return void
+     */
+    abstract protected function authenticate();
+
+    /**
+     * Complete the password grant.
+     *
+     * @throws
+     *
+     * @return array
+     */
+    public function completeFlow()
+    {
+        // Get the required params.
+        $clientId = $this->server->getRequest()->request->get('client_id', $this->server->getRequest()->getUser());
+        if (is_null($clientId)) {
+            throw new InvalidRequestException('client_id');
+        }
+
+        $clientSecret = $this->server->getRequest()->request->get('client_secret',
+            $this->server->getRequest()->getPassword());
+        if (is_null($clientSecret)) {
+            throw new InvalidRequestException('client_secret');
+        }
+
+        // Validate client ID and client secret.
+        $client = $this->server->getClientStorage()->get(
+            $clientId,
+            $clientSecret,
+            null,
+            $this->getIdentifier()
+        );
+
+        if (!($client instanceof ClientEntity)) {
+            $this->server->getEventEmitter()->emit(new ClientAuthenticationFailedEvent($this->server->getRequest()));
+            throw new InvalidClientException();
+        }
+
+        // Authenticate and return the user.
+        $userId = $this->authenticate();
+
+        if (!$userId) {
+            $this->server->getEventEmitter()->emit(new UserAuthenticationFailedEvent($this->server->getRequest()));
+
+            throw new InvalidCredentialsException();
+        }
+
+        // Validate any scopes that are in the request.
+        $scopeParam = $this->server->getRequest()->request->get('scope', '');
+        $scopes = $this->validateScopes($scopeParam, $client);
+
+        // Create a new session.
+        $session = new SessionEntity($this->server);
+        $session->setOwner('user', $userId);
+        $session->associateClient($client);
+
+        // Generate an access token.
+        $accessToken = new AccessTokenEntity($this->server);
+        $accessToken->setId(SecureKey::generate());
+        $accessToken->setExpireTime($this->getAccessTokenTTL() + time());
+
+        // Associate scopes with the session and access token.
+        foreach ($scopes as $scope) {
+            $session->associateScope($scope);
+        }
+
+        foreach ($session->getScopes() as $scope) {
+            $accessToken->associateScope($scope);
+        }
+
+        $this->server->getTokenType()->setSession($session);
+        $this->server->getTokenType()->setParam('access_token', $accessToken->getId());
+        $this->server->getTokenType()->setParam('expires_in', $this->getAccessTokenTTL());
+
+        // Associate a refresh token if set.
+        if ($this->server->hasGrantType('refresh_token')) {
+            $refreshToken = new RefreshTokenEntity($this->server);
+            $refreshToken->setId(SecureKey::generate());
+            $refreshToken->setExpireTime($this->server->getGrantType('refresh_token')->getRefreshTokenTTL() + time());
+            $this->server->getTokenType()->setParam('refresh_token', $refreshToken->getId());
+        }
+
+        // Save everything.
+        $session->save();
+        $accessToken->setSession($session);
+        $accessToken->save();
+
+        if ($this->server->hasGrantType('refresh_token')) {
+            $refreshToken->setAccessToken($accessToken);
+            $refreshToken->save();
+        }
+
+        return $this->server->getTokenType()->generateResponse();
+    }
+}

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * (c) Luca Degasperi <packages@lucadegasperi.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Grant;
+
+use Illuminate\Support\Facades\Auth;
+use League\OAuth2\Server\Exception\InvalidRequestException;
+
+/**
+ * This is the password grant class.
+ *
+ * @author Vincent Klaiber <hello@vinkla.com>
+ */
+class PasswordGrant extends AbstractGrant
+{
+    /**
+     * Validate the data and check the credentials.
+     *
+     * @throws \League\OAuth2\Server\Exception\InvalidRequestException
+     *
+     * @return int|bool
+     */
+    protected function authenticate()
+    {
+        $username = $this->server->getRequest()->request->get('username', null);
+
+        if (is_null($username)) {
+            throw new InvalidRequestException('username');
+        }
+
+        $password = $this->server->getRequest()->request->get('password', null);
+
+        if (is_null($password)) {
+            throw new InvalidRequestException('password');
+        }
+
+        $credentials = [
+            'username' => $username,
+            'password' => password,
+        ];
+
+        if (Auth::attempt($credentials)) {
+            return Auth::user()->id;
+        }
+
+        return false;
+    }
+}

--- a/tests/unit/LucaDegasperi/OAuth2Server/AuthorizerSpec.php
+++ b/tests/unit/LucaDegasperi/OAuth2Server/AuthorizerSpec.php
@@ -60,7 +60,7 @@ class AuthorizerSpec extends ObjectBehavior
 
     public function it_returns_the_current_scopes(ResourceServer $checker, AccessTokenEntity $accessTokenEntity)
     {
-        $accessTokenEntity->getScopes()->willReturn(['foo','bar']);
+        $accessTokenEntity->getScopes()->willReturn(['foo', 'bar']);
         $checker->getAccessToken()->willReturn($accessTokenEntity)->shouldBeCalled();
         $this->getScopes()->shouldReturn(['foo', 'bar']);
     }


### PR DESCRIPTION
This is my proposal to adding custom grants. This will solve the ugly looking callbacks from the configuration files. This could potentially solve the issue seen in #323. It would also make it a lot easier for newcomers to create their own custom grants by extending our simplified `AbstractGrant`.

This is how the configuration file would look:
```php
'client_credentials' => [
    'class' => 'LucaDegasperi\OAuth2Server\Grant\ClientCredentialsGrant',
    'access_token_ttl' => 3600,
],

'password' => [
    'class' => 'LucaDegasperi\OAuth2Server\Grant\PasswordGrant',
    'access_token_ttl' => 604800,
],
```

I've currently named the abstract method to `authenticate()`. Maybe `getUserId()` or similar would be a better name. Also, I haven't added any tests yet. Wanted to share this first. 

@lucadegasperi What do you think? Something you would consider?