### PR TITLE
Enable long-running applications

### DIFF
--- a/src/Middleware/CheckAuthCodeRequestMiddleware.php
+++ b/src/Middleware/CheckAuthCodeRequestMiddleware.php
@@ -48,6 +48,7 @@ class CheckAuthCodeRequestMiddleware
      */
     public function handle($request, Closure $next)
     {
+        $this->authorizer->setRequest($request);
         $this->authorizer->checkAuthCodeRequest();
 
         return $next($request);

--- a/src/Middleware/OAuthMiddleware.php
+++ b/src/Middleware/OAuthMiddleware.php
@@ -67,6 +67,7 @@ class OAuthMiddleware
             $scopes = explode('+', $scopesString);
         }
 
+        $this->authorizer->setRequest($request);
         $this->authorizer->validateAccessToken($this->httpHeadersOnly);
         $this->validateScopes($scopes);
 

--- a/src/Middleware/OAuthOwnerMiddleware.php
+++ b/src/Middleware/OAuthOwnerMiddleware.php
@@ -58,6 +58,7 @@ class OAuthOwnerMiddleware
             $ownerTypes = explode('+', $ownerTypesString);
         }
 
+        $this->authorizer->setRequest($request);
         if (!in_array($this->authorizer->getResourceOwnerType(), $ownerTypes)) {
             throw new AccessDeniedException();
         }

--- a/tests/unit/LucaDegasperi/OAuth2Server/Middleware/CheckAuthCodeRequestMiddlewareSpec.php
+++ b/tests/unit/LucaDegasperi/OAuth2Server/Middleware/CheckAuthCodeRequestMiddlewareSpec.php
@@ -40,6 +40,7 @@ class CheckAuthCodeRequestMiddlewareSpec extends ObjectBehavior
     public function it_calls_the_next_middleware_on_success(Request $request, Authorizer $authorizer)
     {
         $authorizer->checkAuthCodeRequest()->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldThrow(new MiddlewareException('Called execution of $next'))
             ->during('handle', [$request, $this->next]);
@@ -48,6 +49,7 @@ class CheckAuthCodeRequestMiddlewareSpec extends ObjectBehavior
     public function it_exits_on_error(Request $request, Authorizer $authorizer)
     {
         $authorizer->checkAuthCodeRequest()->willThrow(new InvalidRequestException('client_id'))->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldNotThrow(new MiddlewareException('Called execution of $next'))
                 ->during('handle', [$request, $this->next]);

--- a/tests/unit/LucaDegasperi/OAuth2Server/Middleware/OAuthMiddlewareSpec.php
+++ b/tests/unit/LucaDegasperi/OAuth2Server/Middleware/OAuthMiddlewareSpec.php
@@ -41,6 +41,7 @@ class OAuthMiddlewareSpec extends ObjectBehavior
     public function it_blocks_invalid_access_tokens(Request $request, Authorizer $authorizer)
     {
         $authorizer->validateAccessToken(false)->willThrow(new AccessDeniedException())->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldNotThrow(new MiddlewareException('Called execution of $next'))
                 ->during('handle', [$request, $this->next]);
@@ -49,6 +50,7 @@ class OAuthMiddlewareSpec extends ObjectBehavior
     public function it_passes_with_valid_access_token(Request $request, Authorizer $authorizer)
     {
         $authorizer->validateAccessToken(false)->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldThrow(new MiddlewareException('Called execution of $next'))
                 ->during('handle', [$request, $this->next]);
@@ -58,6 +60,7 @@ class OAuthMiddlewareSpec extends ObjectBehavior
     {
         $authorizer->validateAccessToken(false)->shouldBeCalled();
         $authorizer->hasScope(['baz'])->willReturn(false)->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldThrow(new InvalidScopeException('baz'))
                 ->during('handle', [$request, $this->next, 'baz']);
@@ -70,6 +73,7 @@ class OAuthMiddlewareSpec extends ObjectBehavior
     {
         $authorizer->validateAccessToken(false)->shouldBeCalled();
         $authorizer->hasScope(['baz'])->willReturn(true)->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldNotThrow(new InvalidScopeException('baz'))
                 ->during('handle', [$request, $this->next, 'baz']);

--- a/tests/unit/LucaDegasperi/OAuth2Server/Middleware/OAuthOwnerMiddlewareSpec.php
+++ b/tests/unit/LucaDegasperi/OAuth2Server/Middleware/OAuthOwnerMiddlewareSpec.php
@@ -40,6 +40,7 @@ class OAuthOwnerMiddlewareSpec extends ObjectBehavior
     public function it_passes_if_resource_owners_are_allowed(Request $request, Authorizer $authorizer)
     {
         $authorizer->getResourceOwnerType()->willReturn('user')->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldThrow(new MiddlewareException('Called execution of $next'))
                 ->during('handle', [$request, $this->next, 'user']);
@@ -48,6 +49,7 @@ class OAuthOwnerMiddlewareSpec extends ObjectBehavior
     public function it_blocks_if_resource_owners_are_not_allowed(Request $request, Authorizer $authorizer)
     {
         $authorizer->getResourceOwnerType()->willReturn('user')->shouldBeCalled();
+        $authorizer->setRequest($request)->shouldBeCalled();
 
         $this->shouldThrow(new AccessDeniedException())
                 ->during('handle', [$request, $this->next, 'client']);


### PR DESCRIPTION
There was an issue for long running applications that AbstractServer caches first request send to it and on second req it still respond to first one. I fixed this with setting actually processed request before asking AuthorizationServer. __This is important security fix.__