### PR TITLE
return type of create() should be `string`

### DIFF
--- a/src/Storage/FluentClient.php
+++ b/src/Storage/FluentClient.php
@@ -155,7 +155,7 @@ class FluentClient extends AbstractFluentAdapter implements ClientInterface
      * @param string $id The client's unique id
      * @param string $secret The clients' unique secret
      *
-     * @return int
+     * @return string
      */
     public function create($name, $id, $secret)
     {


### PR DESCRIPTION
`id` column of `oauth_clients` is `VARCHAR(40)`. Isn't the return value of `insertGetId()` `string`?