### PR TITLE
Removed need for clientSecret for some grant types

### DIFF
--- a/src/Storage/FluentClient.php
+++ b/src/Storage/FluentClient.php
@@ -77,47 +77,55 @@ class FluentClient extends AbstractFluentAdapter implements ClientInterface
     {
         $query = null;
 
-        if (!is_null($redirectUri) && is_null($clientSecret)) {
+        if (! is_null($redirectUri) && is_null($clientSecret)) {
             $query = $this->getConnection()->table('oauth_clients')
-                   ->select(
-                       'oauth_clients.id as id',
-                       'oauth_clients.secret as secret',
-                       'oauth_client_endpoints.redirect_uri as redirect_uri',
-                       'oauth_clients.name as name')
-                   ->join('oauth_client_endpoints', 'oauth_clients.id', '=', 'oauth_client_endpoints.client_id')
-                   ->where('oauth_clients.id', $clientId)
-                   ->where('oauth_client_endpoints.redirect_uri', $redirectUri);
-        } elseif (!is_null($clientSecret) && is_null($redirectUri)) {
+                ->select(
+                    'oauth_clients.id as id',
+                    'oauth_clients.secret as secret',
+                    'oauth_client_endpoints.redirect_uri as redirect_uri',
+                    'oauth_clients.name as name')
+                ->join('oauth_client_endpoints', 'oauth_clients.id', '=', 'oauth_client_endpoints.client_id')
+                ->where('oauth_clients.id', $clientId)
+                ->where('oauth_client_endpoints.redirect_uri', $redirectUri);
+        } elseif (! is_null($clientSecret) && is_null($redirectUri)) {
             $query = $this->getConnection()->table('oauth_clients')
-                   ->select(
-                       'oauth_clients.id as id',
-                       'oauth_clients.secret as secret',
-                       'oauth_clients.name as name')
-                   ->where('oauth_clients.id', $clientId)
-                   ->where('oauth_clients.secret', $clientSecret);
-        } elseif (!is_null($clientSecret) && !is_null($redirectUri)) {
+                ->select(
+                    'oauth_clients.id as id',
+                    'oauth_clients.secret as secret',
+                    'oauth_clients.name as name')
+                ->where('oauth_clients.id', $clientId)
+                ->where('oauth_clients.secret', $clientSecret);
+        } elseif (! is_null($clientSecret) && ! is_null($redirectUri)) {
             $query = $this->getConnection()->table('oauth_clients')
-                   ->select(
-                       'oauth_clients.id as id',
-                       'oauth_clients.secret as secret',
-                       'oauth_client_endpoints.redirect_uri as redirect_uri',
-                       'oauth_clients.name as name')
-                   ->join('oauth_client_endpoints', 'oauth_clients.id', '=', 'oauth_client_endpoints.client_id')
-                   ->where('oauth_clients.id', $clientId)
-                   ->where('oauth_clients.secret', $clientSecret)
-                   ->where('oauth_client_endpoints.redirect_uri', $redirectUri);
+                ->select(
+                    'oauth_clients.id as id',
+                    'oauth_clients.secret as secret',
+                    'oauth_client_endpoints.redirect_uri as redirect_uri',
+                    'oauth_clients.name as name')
+                ->join('oauth_client_endpoints', 'oauth_clients.id', '=', 'oauth_client_endpoints.client_id')
+                ->where('oauth_clients.id', $clientId)
+                ->where('oauth_clients.secret', $clientSecret)
+                ->where('oauth_client_endpoints.redirect_uri', $redirectUri);
+        } elseif (is_null($clientSecret) && in_array($grantType, ['password', 'refresh_token'])) {
+            $query = $this->getConnection()->table('oauth_clients')
+                ->select(
+                    'oauth_clients.id as id',
+                    'oauth_clients.name as name',
+                    'oauth_clients.secret as secret'
+                )
+                ->where('oauth_clients.id', $clientId);
         }
 
-        if ($this->limitClientsToGrants === true && !is_null($grantType)) {
+        if ($this->limitClientsToGrants === true and ! is_null($grantType)) {
             $query = $query->join('oauth_client_grants', 'oauth_clients.id', '=', 'oauth_client_grants.client_id')
-                   ->join('oauth_grants', 'oauth_grants.id', '=', 'oauth_client_grants.grant_id')
-                   ->where('oauth_grants.id', $grantType);
+                ->join('oauth_grants', 'oauth_grants.id', '=', 'oauth_client_grants.grant_id')
+                ->where('oauth_grants.id', $grantType);
         }
 
         $result = $query->first();
 
         if (is_null($result)) {
-            return;
+            return null;
         }
 
         return $this->hydrateEntity($result);


### PR DESCRIPTION
The `client_secret` shouldn't be necessary when using the `password` or `refresh_token` grant types.
In the former (in cases where client secrets cannot be stored securely), security is handled on a resource owner level, where users in a (for example) mobile web application can login to an application using their own credentials.
In the latter, the new access tokens are retrieved using special "refresh tokens", which are sent back as a part of the regular OAuth2.0 response body when a client has successfully authenticated with some kind of `grant_type`. Asking the client for a client_secret _again_ is unnecessary in my opinion.

To create a bit of context for this PR: I've been using this package (with this proposed change) in a mobile webapplication, where resource owners authenticate once (by simply logging in using their email address and password using the `password` grant) and then just (statelessly) identify themselves using their OAuth2.0 access token. Should the token expire, the client application then simply requests to refresh the token using the `refresh_token` grant. The whole setup consists of an front-end webapplication and a back-end http://jsonapi.org server, where the communication is done by XHR (with CORS). In all OAuth-related requests, only the `client_id` is sent back to the server.

Thoughts?