### PR TITLE
Convert all DB returns to objects to handle all PDO configurations

### DIFF
--- a/src/Storage/FluentAccessToken.php
+++ b/src/Storage/FluentAccessToken.php
@@ -32,7 +32,7 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
      */
     public function get($token)
     {
-        $result = $this->getConnection()->table('oauth_access_tokens')
+        $result = (object) $this->getConnection()->table('oauth_access_tokens')
                 ->where('oauth_access_tokens.id', $token)
                 ->first();
 
@@ -73,7 +73,7 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
      */
     public function getScopes(AccessTokenEntity $token)
     {
-        $result = $this->getConnection()->table('oauth_access_token_scopes')
+        $result = (object) $this->getConnection()->table('oauth_access_token_scopes')
                 ->select('oauth_scopes.*')
                 ->join('oauth_scopes', 'oauth_access_token_scopes.scope_id', '=', 'oauth_scopes.id')
                 ->where('oauth_access_token_scopes.access_token_id', $token->getId())

--- a/src/Storage/FluentAuthCode.php
+++ b/src/Storage/FluentAuthCode.php
@@ -32,7 +32,7 @@ class FluentAuthCode extends AbstractFluentAdapter implements AuthCodeInterface
      */
     public function get($code)
     {
-        $result = $this->getConnection()->table('oauth_auth_codes')
+        $result = (object) $this->getConnection()->table('oauth_auth_codes')
             ->where('oauth_auth_codes.id', $code)
             ->where('oauth_auth_codes.expire_time', '>=', time())
             ->first();
@@ -56,7 +56,7 @@ class FluentAuthCode extends AbstractFluentAdapter implements AuthCodeInterface
      */
     public function getScopes(AuthCodeEntity $token)
     {
-        $result = $this->getConnection()->table('oauth_auth_code_scopes')
+        $result = (object) $this->getConnection()->table('oauth_auth_code_scopes')
             ->select('oauth_scopes.*')
             ->join('oauth_scopes', 'oauth_auth_code_scopes.scope_id', '=', 'oauth_scopes.id')
             ->where('oauth_auth_code_scopes.auth_code_id', $token->getId())

--- a/src/Storage/FluentClient.php
+++ b/src/Storage/FluentClient.php
@@ -114,7 +114,7 @@ class FluentClient extends AbstractFluentAdapter implements ClientInterface
                    ->where('oauth_grants.id', $grantType);
         }
 
-        $result = $query->first();
+        $result = (object) $query->first();
 
         if (is_null($result)) {
             return;

--- a/src/Storage/FluentRefreshToken.php
+++ b/src/Storage/FluentRefreshToken.php
@@ -31,7 +31,7 @@ class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenIn
      */
     public function get($token)
     {
-        $result = $this->getConnection()->table('oauth_refresh_tokens')
+        $result = (object) $this->getConnection()->table('oauth_refresh_tokens')
                 ->where('oauth_refresh_tokens.id', $token)
                 ->where('oauth_refresh_tokens.expire_time', '>=', time())
                 ->first();

--- a/src/Storage/FluentScope.php
+++ b/src/Storage/FluentScope.php
@@ -122,7 +122,7 @@ class FluentScope extends AbstractFluentAdapter implements ScopeInterface
                            ->where('oauth_grants.id', $grantType);
         }
 
-        $result = $query->first();
+        $result = (object) $query->first();
 
         if (is_null($result)) {
             return;

--- a/src/Storage/FluentSession.php
+++ b/src/Storage/FluentSession.php
@@ -34,7 +34,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
      */
     public function get($sessionId)
     {
-        $result = $this->getConnection()->table('oauth_sessions')
+        $result = (object) $this->getConnection()->table('oauth_sessions')
                     ->where('oauth_sessions.id', $sessionId)
                     ->first();
 
@@ -56,7 +56,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
      */
     public function getByAccessToken(AccessTokenEntity $accessToken)
     {
-        $result = $this->getConnection()->table('oauth_sessions')
+        $result = (object) $this->getConnection()->table('oauth_sessions')
                 ->select('oauth_sessions.*')
                 ->join('oauth_access_tokens', 'oauth_sessions.id', '=', 'oauth_access_tokens.session_id')
                 ->where('oauth_access_tokens.id', $accessToken->getId())
@@ -81,7 +81,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
     public function getScopes(SessionEntity $session)
     {
         // TODO: Check this before pushing
-        $result = $this->getConnection()->table('oauth_session_scopes')
+        $result = (object) $this->getConnection()->table('oauth_session_scopes')
                   ->select('oauth_scopes.*')
                   ->join('oauth_scopes', 'oauth_session_scopes.scope_id', '=', 'oauth_scopes.id')
                   ->where('oauth_session_scopes.session_id', $session->getId())
@@ -148,7 +148,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
      */
     public function getByAuthCode(AuthCodeEntity $authCode)
     {
-        $result = $this->getConnection()->table('oauth_sessions')
+        $result = (object) $this->getConnection()->table('oauth_sessions')
             ->select('oauth_sessions.*')
             ->join('oauth_auth_codes', 'oauth_sessions.id', '=', 'oauth_auth_codes.session_id')
             ->where('oauth_auth_codes.id', $authCode->getId())


### PR DESCRIPTION
if Laravel's PDO configuration is set to PDO_FETCH_ASSOC, this package fails as it attempts to get properties of non-objects (as they are associative arrays). This pr handles that by ensuring all returns are loaded into stdobjs if they are not already objects and then grants access to those properties. This was addressed in #99 and #100 but was lost in the rewrite.