### PR TITLE
MongoDB storage support.

### DIFF
--- a/src/Storage/Mongo/AbstractFluentAdapter.php
+++ b/src/Storage/Mongo/AbstractFluentAdapter.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use League\OAuth2\Server\Storage\AbstractStorage;
+
+/**
+ * This is the abstract fluent adapter class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+abstract class AbstractFluentAdapter extends AbstractStorage
+{
+    /**
+     * The connection resolver instance.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $resolver;
+
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    protected $connectionName;
+
+    /**
+     * Create a new abstract fluent adapter instance.
+     *
+     * @param \Illuminate\Database\ConnectionResolverInterface $resolver
+     */
+    public function __construct(Resolver $resolver)
+    {
+        $this->resolver = $resolver;
+        $this->connectionName = null;
+    }
+
+    /**
+     * Set the resolver.
+     *
+     * @param \Illuminate\Database\ConnectionResolverInterface $resolver
+     */
+    public function setResolver(Resolver $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Get the resolver.
+     *
+     * @return \Illuminate\Database\ConnectionResolverInterface
+     */
+    public function getResolver()
+    {
+        return $this->resolver;
+    }
+
+    /**
+     * Set the connection name.
+     *
+     * @param string $connectionName
+     */
+    public function setConnectionName($connectionName)
+    {
+        $this->connectionName = $connectionName;
+    }
+
+    /**
+     * Get the connection.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function getConnection()
+    {
+        return $this->resolver->connection($this->connectionName);
+    }
+}

--- a/src/Storage/Mongo/FluentAccessToken.php
+++ b/src/Storage/Mongo/FluentAccessToken.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Carbon\Carbon;
+use League\OAuth2\Server\Entity\AccessTokenEntity;
+use League\OAuth2\Server\Entity\ScopeEntity;
+use League\OAuth2\Server\Storage\AccessTokenInterface;
+
+/**
+ * This is the fluent access token class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInterface
+{
+    /**
+     * Get an instance of Entities\AccessToken.
+     *
+     * @param string $token The access token
+     *
+     * @return null|AbstractTokenEntity
+     */
+    public function get($token)
+    {
+        $result = $this->getConnection()->table('oauth_access_tokens')
+            ->where('id', $token)->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        return (new AccessTokenEntity($this->getServer()))
+               ->setId($result['id'])
+               ->setExpireTime((int) $result['expire_time']);
+    }
+
+    /**
+     * Get the scopes for an access token.
+     *
+     * @param \League\OAuth2\Server\Entity\AccessTokenEntity $token The access token
+     *
+     * @return array Array of \League\OAuth2\Server\Entity\ScopeEntity
+     */
+    public function getScopes(AccessTokenEntity $token)
+    {
+        $result = $this->getConnection()->table('oauth_access_token_scopes')
+            ->where('access_token_id', $token->getId())->get();
+
+        foreach ($result as &$row) {
+            $row = $this->getConnection()->table('oauth_scopes')
+                ->where('id', $row['scope_id'])->first();
+        }
+
+        $scopes = [];
+
+        foreach ($result as $scope) {
+            $scopes[] = (new ScopeEntity($this->getServer()))->hydrate([
+                'id' => $scope['id'],
+                'description' => $scope['description'],
+            ]);
+        }
+
+        return $scopes;
+    }
+
+    /**
+     * Creates a new access token.
+     *
+     * @param string     $token      The access token
+     * @param int        $expireTime The expire time expressed as a unix timestamp
+     * @param string|int $sessionId  The session ID
+     *
+     * @return \League\OAuth2\Server\Entity\AccessTokenEntity
+     */
+    public function create($token, $expireTime, $sessionId)
+    {
+        $this->getConnection()->table('oauth_access_tokens')->insert([
+            'id' => $token,
+            'expire_time' => $expireTime,
+            'session_id' => $sessionId,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+
+        return (new AccessTokenEntity($this->getServer()))
+            ->setId($token)
+            ->setExpireTime((int) $expireTime);
+    }
+
+    /**
+     * Associate a scope with an access token.
+     *
+     * @param \League\OAuth2\Server\Entity\AccessTokenEntity $token The access token
+     * @param \League\OAuth2\Server\Entity\ScopeEntity       $scope The scope
+     */
+    public function associateScope(AccessTokenEntity $token, ScopeEntity $scope)
+    {
+        $this->getConnection()->table('oauth_access_token_scopes')->insert([
+            'access_token_id' => $token->getId(),
+            'scope_id' => $scope->getId(),
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * Delete an access token.
+     *
+     * @param \League\OAuth2\Server\Entity\AccessTokenEntity $token The access token to delete
+     */
+    public function delete(AccessTokenEntity $token)
+    {
+        $this->getConnection()->table('oauth_access_tokens')
+        ->where('id', $token->getId())->delete();
+        $this->getConnection()->table('oauth_access_token_scopes')
+        ->where('access_token_id', $token->getId())->delete();
+    }
+}

--- a/src/Storage/Mongo/FluentAuthCode.php
+++ b/src/Storage/Mongo/FluentAuthCode.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Carbon\Carbon;
+use League\OAuth2\Server\Entity\AuthCodeEntity;
+use League\OAuth2\Server\Entity\ScopeEntity;
+use League\OAuth2\Server\Storage\AuthCodeInterface;
+
+/**
+ * This is the fluent auth code class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+class FluentAuthCode extends AbstractFluentAdapter implements AuthCodeInterface
+{
+    /**
+     * Get the auth code.
+     *
+     * @param string $code
+     *
+     * @return \League\OAuth2\Server\Entity\AuthCodeEntity
+     */
+    public function get($code)
+    {
+        $result = $this->getConnection()->table('oauth_auth_codes')
+            ->where('id', $code)
+            ->where('expire_time', '>=', time())
+            ->first();
+
+        if (is_null($result)) {
+            return;
+        }
+
+        return (new AuthCodeEntity($this->getServer()))
+            ->setId($result['id'])
+            ->setRedirectUri($result['redirect_uri'])
+            ->setExpireTime((int) $result['expire_time']);
+    }
+
+    /**
+     * Get the scopes for an access token.
+     *
+     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
+     *
+     * @return array Array of \League\OAuth2\Server\Entity\ScopeEntity
+     */
+    public function getScopes(AuthCodeEntity $token)
+    {
+        $result = $this->getConnection()->table('oauth_auth_code_scopes')
+                ->where('auth_code_id', $token->getId())
+                ->get();
+
+        foreach ($result as &$row) {
+            $row = $this->getConnection()->table('oauth_scopes')
+                    ->where('id', $row['scope_id'])
+                    ->first();
+        }
+
+        $scopes = [];
+
+        foreach ($result as $scope) {
+            $scopes[] = (new ScopeEntity($this->getServer()))->hydrate([
+                'id' => $scope['id'],
+                'description' => $scope['description'],
+            ]);
+        }
+
+        return $scopes;
+    }
+
+    /**
+     * Associate a scope with an access token.
+     *
+     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
+     * @param \League\OAuth2\Server\Entity\ScopeEntity    $scope The scope
+     */
+    public function associateScope(AuthCodeEntity $token, ScopeEntity $scope)
+    {
+        $this->getConnection()->table('oauth_auth_code_scopes')->insert([
+            'auth_code_id' => $token->getId(),
+            'scope_id' => $scope->getId(),
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * Delete an access token.
+     *
+     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The access token to delete
+     */
+    public function delete(AuthCodeEntity $token)
+    {
+        $this->getConnection()->table('oauth_auth_codes')
+        ->where('id', $token->getId())
+        ->delete();
+        $this->getConnection()->table('oauth_auth_code_scopes')
+        ->where('auth_code_id', $token->getId())
+        ->delete();
+    }
+
+    /**
+     * Create an auth code.
+     *
+     * @param string $token       The token ID
+     * @param int    $expireTime  Token expire time
+     * @param int    $sessionId   Session identifier
+     * @param string $redirectUri Client redirect uri
+     */
+    public function create($token, $expireTime, $sessionId, $redirectUri)
+    {
+        $this->getConnection()->table('oauth_auth_codes')->insert([
+            'id' => $token,
+            'session_id' => $sessionId,
+            'redirect_uri' => $redirectUri,
+            'expire_time' => $expireTime,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+    }
+}

--- a/src/Storage/Mongo/FluentClient.php
+++ b/src/Storage/Mongo/FluentClient.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Carbon\Carbon;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use League\OAuth2\Server\Entity\ClientEntity;
+use League\OAuth2\Server\Entity\SessionEntity;
+use League\OAuth2\Server\Storage\ClientInterface;
+
+/**
+ * This is the fluent client class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+class FluentClient extends AbstractFluentAdapter implements ClientInterface
+{
+    /**
+     * Limit clients to grants.
+     *
+     * @var bool
+     */
+    protected $limitClientsToGrants = false;
+
+    /**
+     * Create a new fluent client instance.
+     *
+     * @param \Illuminate\Database\ConnectionResolverInterface $resolver
+     * @param bool                                             $limitClientsToGrants
+     */
+    public function __construct(Resolver $resolver, $limitClientsToGrants = false)
+    {
+        parent::__construct($resolver);
+        $this->limitClientsToGrants = $limitClientsToGrants;
+    }
+
+    /**
+     * Check if clients are limited to grants.
+     *
+     * @return bool
+     */
+    public function areClientsLimitedToGrants()
+    {
+        return $this->limitClientsToGrants;
+    }
+
+    /**
+     * Whether or not to limit clients to grants.
+     *
+     * @param bool $limit
+     */
+    public function limitClientsToGrants($limit = false)
+    {
+        $this->limitClientsToGrants = $limit;
+    }
+
+    /**
+     * Get the client.
+     *
+     * @param string $clientId
+     * @param string $clientSecret
+     * @param string $redirectUri
+     * @param string $grantType
+     *
+     * @return null|\League\OAuth2\Server\Entity\ClientEntity
+     */
+    public function get($clientId, $clientSecret = null, $redirectUri = null, $grantType = null)
+    {
+        // Get client
+        $where = is_null($clientSecret) ? ['id' => $clientId] : ['id' => $clientId, 'secret' => $clientSecret];
+        $client = $this->getConnection()->table('oauth_clients')->where($where)->first();
+        if (is_null($client)) {
+            return;
+        }
+
+        if ($redirectUri) {
+            // Get client endpoint
+            $where = ['client_id' => (String) $client['_id'], 'redirect_uri' => $redirectUri];
+            $endpoint = $this->getConnection()->table('oauth_client_endpoints')->where($where)->first();
+            if (is_null($endpoint)) {
+                return;
+            }
+        }
+
+        if ($this->limitClientsToGrants === true && !is_null($grantType)) {
+            // Get grant
+            $where = ['id' => $grantType];
+            $grant = $this->getConnection()->table('oauth_grants')->where($where)->first();
+            if (is_null($grant)) {
+                return;
+            }
+
+            // Get client grant
+            $where = ['client_id' => (string) $client['_id'], 'grant_id' => (string) $grant['_id']];
+            $clientGrant = $this->getConnection()->table('oauth_client_grants')->where($where)->first();
+            if (is_null($clientGrant)) {
+                return;
+            }
+        }
+
+        return $this->hydrateEntity($client);
+    }
+
+    /**
+     * Get the client associated with a session.
+     *
+     * @param \League\OAuth2\Server\Entity\SessionEntity $session The session
+     *
+     * @return null|\League\OAuth2\Server\Entity\ClientEntity
+     */
+    public function getBySession(SessionEntity $session)
+    {
+        $result = $this->getConnection()->table('oauth_sessions')
+            ->where('_id', $session->getId())->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        $result = $this->getConnection()->table('oauth_clients')
+            ->where('id', $result['client_id'])->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        return $this->hydrateEntity($result);
+    }
+
+    /**
+     * Create a new client.
+     *
+     * @param string $name   The client's unique name
+     * @param string $id     The client's unique id
+     * @param string $secret The clients' unique secret
+     *
+     * @return string
+     */
+    public function create($name, $id, $secret)
+    {
+        return $this->getConnection()->table('oauth_clients')->insertGetId([
+            'id' => $id,
+            'name' => $name,
+            'secret' => $secret,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * Hydrate the entity.
+     *
+     * @param $result
+     *
+     * @return \League\OAuth2\Server\Entity\ClientEntity
+     */
+    protected function hydrateEntity($result)
+    {
+        $client = new ClientEntity($this->getServer());
+        $client->hydrate([
+            'id' => $result['id'],
+            'name' => $result['name'],
+            'secret' => $result['secret'],
+            'redirectUri' => (isset($result->redirect_uri) ? $result->redirect_uri : null),
+        ]);
+
+        return $client;
+    }
+}

--- a/src/Storage/Mongo/FluentRefreshToken.php
+++ b/src/Storage/Mongo/FluentRefreshToken.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Carbon\Carbon;
+use League\OAuth2\Server\Entity\RefreshTokenEntity;
+use League\OAuth2\Server\Storage\RefreshTokenInterface;
+
+/**
+ * This is the fluent refresh token class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenInterface
+{
+    /**
+     * Return a new instance of \League\OAuth2\Server\Entity\RefreshTokenEntity.
+     *
+     * @param string $token
+     *
+     * @return \League\OAuth2\Server\Entity\RefreshTokenEntity
+     */
+    public function get($token)
+    {
+        $result = $this->getConnection()->table('oauth_refresh_tokens')
+                ->where('id', $token)
+                ->where('expire_time', '>=', time())
+                ->first();
+
+        if (is_null($result)) {
+            return;
+        }
+
+        return (new RefreshTokenEntity($this->getServer()))
+               ->setId($result['id'])
+               ->setAccessTokenId($result['access_token_id'])
+               ->setExpireTime((int) $result['expire_time']);
+    }
+
+    /**
+     * Create a new refresh token_name.
+     *
+     * @param string $token
+     * @param int    $expireTime
+     * @param string $accessToken
+     *
+     * @return \League\OAuth2\Server\Entity\RefreshTokenEntity
+     */
+    public function create($token, $expireTime, $accessToken)
+    {
+        $this->getConnection()->table('oauth_refresh_tokens')->insert([
+            'id' => $token,
+            'expire_time' => $expireTime,
+            'access_token_id' => $accessToken,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+
+        return (new RefreshTokenEntity($this->getServer()))
+               ->setId($token)
+               ->setAccessTokenId($accessToken)
+               ->setExpireTime((int) $expireTime);
+    }
+
+    /**
+     * Delete the refresh token.
+     *
+     * @param \League\OAuth2\Server\Entity\RefreshTokenEntity $token
+     */
+    public function delete(RefreshTokenEntity $token)
+    {
+        $this->getConnection()->table('oauth_refresh_tokens')
+        ->where('id', $token->getId())
+        ->delete();
+    }
+}

--- a/src/Storage/Mongo/FluentScope.php
+++ b/src/Storage/Mongo/FluentScope.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use League\OAuth2\Server\Entity\ScopeEntity;
+use League\OAuth2\Server\Storage\ScopeInterface;
+
+/**
+ * This is the fluent scope class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+class FluentScope extends AbstractFluentAdapter implements ScopeInterface
+{
+    /*
+     * Limit clients to scopes.
+     *
+     * @var bool
+     */
+    protected $limitClientsToScopes = false;
+
+    /*
+     * Limit scopes to grants.
+     *
+     * @var bool
+     */
+    protected $limitScopesToGrants = false;
+
+    /**
+     * Create a new fluent scope instance.
+     *
+     * @param \Illuminate\Database\ConnectionResolverInterface $resolver
+     * @param bool|false                                       $limitClientsToScopes
+     * @param bool|false                                       $limitScopesToGrants
+     */
+    public function __construct(Resolver $resolver, $limitClientsToScopes = false, $limitScopesToGrants = false)
+    {
+        parent::__construct($resolver);
+        $this->limitClientsToScopes = $limitClientsToScopes;
+        $this->limitScopesToGrants = $limitScopesToGrants;
+    }
+
+    /**
+     * Set limit clients to scopes.
+     *
+     * @param bool|false $limit
+     */
+    public function limitClientsToScopes($limit = false)
+    {
+        $this->limitClientsToScopes = $limit;
+    }
+
+    /**
+     * Set limit scopes to grants.
+     *
+     * @param bool|false $limit
+     */
+    public function limitScopesToGrants($limit = false)
+    {
+        $this->limitScopesToGrants = $limit;
+    }
+
+    /**
+     * Check if clients are limited to scopes.
+     *
+     * @return bool|false
+     */
+    public function areClientsLimitedToScopes()
+    {
+        return $this->limitClientsToScopes;
+    }
+
+    /**
+     * Check if scopes are limited to grants.
+     *
+     * @return bool|false
+     */
+    public function areScopesLimitedToGrants()
+    {
+        return $this->limitScopesToGrants;
+    }
+
+    /**
+     * Return information about a scope.
+     *
+     * Example SQL query:
+     *
+     * <code>
+     * SELECT * FROM oauth_scopes WHERE scope = :scope
+     * </code>
+     *
+     * @param string $scope     The scope
+     * @param string $grantType The grant type used in the request (default = "null")
+     * @param string $clientId  The client id used for the request (default = "null")
+     *
+     * @return \League\OAuth2\Server\Entity\ScopeEntity|null If the scope doesn't exist return false
+     */
+    public function get($scopeId, $grantType = null, $clientId = null)
+    {
+        // Get scope
+        $scope = $this->getConnection()->table('oauth_scopes')
+            ->where(['id' => $scopeId])->first();
+
+        if (is_null($scope)) {
+            return;
+        }
+
+        if ($this->limitClientsToScopes === true && !is_null($clientId)) {
+            // Get client
+            $client = $this->getConnection()->table('oauth_clients')
+                ->where(['id' => $clientId])->first();
+            if (is_null($client)) {
+                return;
+            }
+
+            // Get client scope
+            $clientScope = $this->getConnection()->table('oauth_client_scopes')
+                ->where(['client_id' => (String) $client['_id'], 'scope_id' => (String) $scope['_id']])->first();
+            if (is_null($clientScope)) {
+                return;
+            }
+        }
+
+        if ($this->limitScopesToGrants === true && !is_null($grantType)) {
+            // Get grant
+            $grant = $this->getConnection()->table('oauth_grants')
+                ->where(['id' => $grantType])->first();
+            if (is_null($grant)) {
+                return;
+            }
+
+            // Get grant scope
+            $grantScope = $this->getConnection()->table('oauth_grant_scopes')
+                ->where(['grant_id' => (String) $grant['_id'], 'scope_id' => (String) $scope['_id']])->first();
+            if (is_null($grantScope)) {
+                return;
+            }
+        }
+
+        $scopeEntity = new ScopeEntity($this->getServer());
+        $scopeEntity->hydrate([
+            'id' => $scope['id'],
+            'description' => $scope['description'],
+        ]);
+
+        return $scopeEntity;
+    }
+}

--- a/src/Storage/Mongo/FluentSession.php
+++ b/src/Storage/Mongo/FluentSession.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Carbon\Carbon;
+use League\OAuth2\Server\Entity\AccessTokenEntity;
+use League\OAuth2\Server\Entity\AuthCodeEntity;
+use League\OAuth2\Server\Entity\ScopeEntity;
+use League\OAuth2\Server\Entity\SessionEntity;
+use League\OAuth2\Server\Storage\SessionInterface;
+
+/**
+ * This is the fluent session class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+class FluentSession extends AbstractFluentAdapter implements SessionInterface
+{
+    /**
+     * Get a session from it's identifier.
+     *
+     * @param string $sessionId
+     *
+     * @return \League\OAuth2\Server\Entity\SessionEntity
+     */
+    public function get($sessionId)
+    {
+        $result = $this->getConnection()->table('oauth_sessions')
+            ->where('_id', $sessionId)->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        return (new SessionEntity($this->getServer()))
+           ->setId($result['_id'])
+           ->setOwner($result['owner_type'], $result['owner_id']);
+    }
+
+    /**
+     * Get a session from an access token.
+     *
+     * @param \League\OAuth2\Server\Entity\AccessTokenEntity $accessToken The access token
+     *
+     * @return \League\OAuth2\Server\Entity\SessionEntity
+     */
+    public function getByAccessToken(AccessTokenEntity $accessToken)
+    {
+        $result = $this->getConnection()->table('oauth_access_tokens')
+            ->where('id', $accessToken->getId())->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        $result = $this->getConnection()->table('oauth_sessions')
+            ->where('_id', $result['session_id'])->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        return (new SessionEntity($this->getServer()))
+           ->setId($result['_id'])
+           ->setOwner($result['owner_type'], $result['owner_id']);
+    }
+
+    /**
+     * Get a session's scopes.
+     *
+     * @param \League\OAuth2\Server\Entity\SessionEntity
+     *
+     * @return array Array of \League\OAuth2\Server\Entity\ScopeEntity
+     */
+    public function getScopes(SessionEntity $session)
+    {
+        $result = $this->getConnection()->table('oauth_session_scopes')
+            ->where('session_id', $session->getId())->get();
+
+        foreach ($result as &$row) {
+            $row = $this->getConnection()->table('oauth_scopes')
+                ->where('id', $row['scope_id'])->first();
+        }
+
+        $scopes = [];
+
+        foreach ($result as $scope) {
+            $scopes[] = (new ScopeEntity($this->getServer()))->hydrate([
+                'id' => $scope['id'],
+                'description' => $scope['description'],
+            ]);
+        }
+
+        return $scopes;
+    }
+
+    /**
+     * Create a new session.
+     *
+     * @param string $ownerType         Session owner's type (user, client)
+     * @param string $ownerId           Session owner's ID
+     * @param string $clientId          Client ID
+     * @param string $clientRedirectUri Client redirect URI (default = null)
+     *
+     * @return int The session's ID
+     */
+    public function create($ownerType, $ownerId, $clientId, $clientRedirectUri = null)
+    {
+        return $this->getConnection()->table('oauth_sessions')->insertGetId([
+            'client_id' => $clientId,
+            'owner_type' => $ownerType,
+            'owner_id' => $ownerId,
+            'client_redirect_uri' => $clientRedirectUri,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * Associate a scope with a session.
+     *
+     * @param \League\OAuth2\Server\Entity\SessionEntity $session
+     * @param \League\OAuth2\Server\Entity\ScopeEntity   $scope   The scopes ID might be an integer or string
+     */
+    public function associateScope(SessionEntity $session, ScopeEntity $scope)
+    {
+        $this->getConnection()->table('oauth_session_scopes')->insert([
+            'session_id' => $session->getId(),
+            'scope_id' => $scope->getId(),
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * Get a session from an aut  code.
+     *
+     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $authCode The auth code
+     *
+     * @return \League\OAuth2\Server\Entity\SessionEntity
+     */
+    public function getByAuthCode(AuthCodeEntity $authCode)
+    {
+        $result = $this->getConnection()->table('oauth_auth_codes')
+            ->where('id', $authCode->getId())->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        $result = $this->getConnection()->table('oauth_sessions')
+            ->where('_id', $result['session_id'])->first();
+        if (is_null($result)) {
+            return;
+        }
+
+        return (new SessionEntity($this->getServer()))
+           ->setId($result['_id'])
+           ->setOwner($result['owner_type'], $result['owner_id']);
+    }
+}

--- a/src/Storage/Mongo/FluentStorageServiceProvider.php
+++ b/src/Storage/Mongo/FluentStorageServiceProvider.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of OAuth 2.0 Laravel.
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Choy Peng Kong <pk@vanitee.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace LucaDegasperi\OAuth2Server\Storage\Mongo;
+
+use Illuminate\Support\ServiceProvider;
+use League\OAuth2\Server\Storage\AccessTokenInterface;
+use League\OAuth2\Server\Storage\AuthCodeInterface;
+use League\OAuth2\Server\Storage\ClientInterface;
+use League\OAuth2\Server\Storage\RefreshTokenInterface;
+use League\OAuth2\Server\Storage\ScopeInterface;
+use League\OAuth2\Server\Storage\SessionInterface;
+
+/**
+ * This is the fluent storage service provider class.
+ *
+ * @author Luca Degasperi <packages@lucadegasperi.com>
+ */
+class FluentStorageServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application events.
+     */
+    public function boot()
+    {
+        //
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register()
+    {
+        $this->registerStorageBindings();
+        $this->registerInterfaceBindings();
+    }
+
+    /**
+     * Bind the storage implementations to the IoC container.
+     */
+    public function registerStorageBindings()
+    {
+        $provider = $this;
+
+        $this->app->bindShared(FluentAccessToken::class, function () use ($provider) {
+            $storage = new FluentAccessToken($provider->app['db']);
+            $storage->setConnectionName($provider->getConnectionName());
+
+            return $storage;
+        });
+
+        $this->app->bindShared(FluentAuthCode::class, function () use ($provider) {
+            $storage = new FluentAuthCode($provider->app['db']);
+            $storage->setConnectionName($provider->getConnectionName());
+
+            return $storage;
+        });
+
+        $this->app->bindShared(FluentClient::class, function ($app) use ($provider) {
+            $limitClientsToGrants = $app['config']->get('oauth2.limit_clients_to_grants');
+            $storage = new FluentClient($provider->app['db'], $limitClientsToGrants);
+            $storage->setConnectionName($provider->getConnectionName());
+
+            return $storage;
+        });
+
+        $this->app->bindShared(FluentRefreshToken::class, function () use ($provider) {
+            $storage = new FluentRefreshToken($provider->app['db']);
+            $storage->setConnectionName($provider->getConnectionName());
+
+            return $storage;
+        });
+
+        $this->app->bindShared(FluentScope::class, function ($app) use ($provider) {
+            $limitClientsToScopes = $app['config']->get('oauth2.limit_clients_to_scopes');
+            $limitScopesToGrants = $app['config']->get('oauth2.limit_scopes_to_grants');
+            $storage = new FluentScope($provider->app['db'], $limitClientsToScopes, $limitScopesToGrants);
+            $storage->setConnectionName($provider->getConnectionName());
+
+            return $storage;
+        });
+
+        $this->app->bindShared(FluentSession::class, function () use ($provider) {
+            $storage = new FluentSession($provider->app['db']);
+            $storage->setConnectionName($provider->getConnectionName());
+
+            return $storage;
+        });
+    }
+
+    /**
+     * Bind the interfaces to their implementations.
+     */
+    public function registerInterfaceBindings()
+    {
+        $this->app->bind(ClientInterface::class, FluentClient::class);
+        $this->app->bind(ScopeInterface::class, FluentScope::class);
+        $this->app->bind(SessionInterface::class, FluentSession::class);
+        $this->app->bind(AuthCodeInterface::class, FluentAuthCode::class);
+        $this->app->bind(AccessTokenInterface::class, FluentAccessToken::class);
+        $this->app->bind(RefreshTokenInterface::class, FluentRefreshToken::class);
+    }
+
+    /**
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return ($this->app['config']->get('oauth2.database') !== 'default') ? $this->app['config']->get('oauth2.database') : null;
+    }
+}


### PR DESCRIPTION
# How to use:

In the app.php file, replace the standard storage service provider with the new storage\mongo service provider.

    LucaDegasperi\OAuth2Server\Storage\Mongo\FluentStorageServiceProvider::class,

# What was done:

- Created Mongo folder inside Storage folder to house concrete classes for mongo support.
- Rewrote all joins as separate queries since mongo doesn't support joins.
- Added additional delete queries to simulate sql database cascade delete.

# Other notes:

- I've tested everything manually, 100% of original functionality should work on mongodb with this patch. I've not written any phpunit test yet.
- Not total "D.R.Y" as the AbstractFluentAdaptor.php and FluentStorageServiceProvider.php in the Mongo folder is an exact duplicate of the original except for the namespace... the alternative i think would be much more complex (implementing an driver/adapter pattern to swap between different types of databases. sql vs nonsql) or maybe I just can't see the better solution.
- I've not tested but the patch should make this library work with all other NoSQL database. i.e. this patch really isn't mongodb-specific.