### PR TITLE
Fixed simple typo in lumen.md

### DIFF
--- a/docs/getting-started/lumen.md
+++ b/docs/getting-started/lumen.md
@@ -31,7 +31,7 @@ $app->routeMiddleware([
     'check-authorization-params' => \LucaDegasperi\OAuth2Server\Middleware\CheckAuthCodeRequestMiddleware::class,
     'csrf' => \Laravel\Lumen\Http\Middleware\VerifyCsrfToken::class,
     'oauth' => \LucaDegasperi\OAuth2Server\Middleware\OAuthMiddleware::class,
-    'oauth-client' => \LucaDegasperi\OAuth2Server\Middleware\OAuthClientrOwnerMiddleware::class,
+    'oauth-client' => \LucaDegasperi\OAuth2Server\Middleware\OAuthClientOwnerMiddleware::class,
     'oauth-user' => \LucaDegasperi\OAuth2Server\Middleware\OAuthUserOwnerMiddleware::class,
 ]);
 ```


### PR DESCRIPTION
Fixed a typing error where `Client` said `Clientr` in the documentation.