### PR TITLE
Add trailing commas to array elements to maintain consistency and mak…

### DIFF
--- a/docs/getting-started/laravel-5.md
+++ b/docs/getting-started/laravel-5.md
@@ -21,7 +21,7 @@ Add this line to the `aliases` array:
 
 Add the following line to your `app/Http/Kernel.php` file in the `$middleware` array
 ```php
-\LucaDegasperi\OAuth2Server\Middleware\OAuthExceptionHandlerMiddleware::class
+\LucaDegasperi\OAuth2Server\Middleware\OAuthExceptionHandlerMiddleware::class,
 ```
 This will catch any OAuth error and respond appropriately.
 
@@ -30,7 +30,7 @@ Then add
 'oauth' => \LucaDegasperi\OAuth2Server\Middleware\OAuthMiddleware::class,
 'oauth-user' => \LucaDegasperi\OAuth2Server\Middleware\OAuthUserOwnerMiddleware::class,
 'oauth-client' => \LucaDegasperi\OAuth2Server\Middleware\OAuthClientOwnerMiddleware::class,
-'check-authorization-params' => \LucaDegasperi\OAuth2Server\Middleware\CheckAuthCodeRequestMiddleware::class
+'check-authorization-params' => \LucaDegasperi\OAuth2Server\Middleware\CheckAuthCodeRequestMiddleware::class,
 ```
 to the `$routeMiddleware` array.
 


### PR DESCRIPTION
…e for prettier commits on users end

Trailing commas for array elements have become an standard because they allow other elements to be appended to the array and make for prettier (and more practical) diff messages.

Trailing commas where already used on other place for the documentation.