### PR TITLE
Allow custom grant_types to reuse existing classes

### DIFF
--- a/src/OAuth2ServerServiceProvider.php
+++ b/src/OAuth2ServerServiceProvider.php
@@ -140,7 +140,7 @@ class OAuth2ServerServiceProvider extends ServiceProvider
                     $grant->setRefreshTokenRotation($grantParams['rotate_refresh_tokens']);
                 }
 
-                $issuer->addGrantType($grant);
+                $issuer->addGrantType($grant, $grantIdentifier);
             }
 
             $checker = $app->make(ResourceServer::class);


### PR DESCRIPTION
I use it to define a custom grant_type `foo` that behaves the same as the `password` grant type, but with a different `access_token_ttl`.