### PR TITLE
Fix for lumen 5.2

### DIFF
--- a/src/Storage/FluentStorageServiceProvider.php
+++ b/src/Storage/FluentStorageServiceProvider.php
@@ -11,7 +11,6 @@
 
 namespace LucaDegasperi\OAuth2Server\Storage;
 
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use League\OAuth2\Server\Storage\AccessTokenInterface;
 use League\OAuth2\Server\Storage\AuthCodeInterface;
@@ -44,36 +43,34 @@ class FluentStorageServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->registerStorageBindings($this->app);
-        $this->registerInterfaceBindings($this->app);
+        $this->registerStorageBindings();
+        $this->registerInterfaceBindings();
     }
 
     /**
      * Bind the storage implementations to the IoC container.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
-     *
      * @return void
      */
-    public function registerStorageBindings(Application $app)
+    public function registerStorageBindings()
     {
         $provider = $this;
 
-        $app->singleton(FluentAccessToken::class, function () use ($provider) {
+        $this->app->singleton(FluentAccessToken::class, function () use ($provider) {
             $storage = new FluentAccessToken($provider->app['db']);
             $storage->setConnectionName($provider->getConnectionName());
 
             return $storage;
         });
 
-        $app->singleton(FluentAuthCode::class, function () use ($provider) {
+        $this->app->singleton(FluentAuthCode::class, function () use ($provider) {
             $storage = new FluentAuthCode($provider->app['db']);
             $storage->setConnectionName($provider->getConnectionName());
 
             return $storage;
         });
 
-        $app->singleton(FluentClient::class, function ($app) use ($provider) {
+        $this->app->singleton(FluentClient::class, function ($app) use ($provider) {
             $limitClientsToGrants = $app['config']->get('oauth2.limit_clients_to_grants');
             $storage = new FluentClient($provider->app['db'], $limitClientsToGrants);
             $storage->setConnectionName($provider->getConnectionName());
@@ -81,14 +78,14 @@ class FluentStorageServiceProvider extends ServiceProvider
             return $storage;
         });
 
-        $app->singleton(FluentRefreshToken::class, function () use ($provider) {
+        $this->app->singleton(FluentRefreshToken::class, function () use ($provider) {
             $storage = new FluentRefreshToken($provider->app['db']);
             $storage->setConnectionName($provider->getConnectionName());
 
             return $storage;
         });
 
-        $app->singleton(FluentScope::class, function ($app) use ($provider) {
+        $this->app->singleton(FluentScope::class, function ($app) use ($provider) {
             $limitClientsToScopes = $app['config']->get('oauth2.limit_clients_to_scopes');
             $limitScopesToGrants = $app['config']->get('oauth2.limit_scopes_to_grants');
             $storage = new FluentScope($provider->app['db'], $limitClientsToScopes, $limitScopesToGrants);
@@ -97,7 +94,7 @@ class FluentStorageServiceProvider extends ServiceProvider
             return $storage;
         });
 
-        $app->singleton(FluentSession::class, function () use ($provider) {
+        $this->app->singleton(FluentSession::class, function () use ($provider) {
             $storage = new FluentSession($provider->app['db']);
             $storage->setConnectionName($provider->getConnectionName());
 
@@ -108,18 +105,16 @@ class FluentStorageServiceProvider extends ServiceProvider
     /**
      * Bind the interfaces to their implementations.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
-     *
      * @return void
      */
-    public function registerInterfaceBindings(Application $app)
+    public function registerInterfaceBindings()
     {
-        $app->bind(ClientInterface::class, FluentClient::class);
-        $app->bind(ScopeInterface::class, FluentScope::class);
-        $app->bind(SessionInterface::class, FluentSession::class);
-        $app->bind(AuthCodeInterface::class, FluentAuthCode::class);
-        $app->bind(AccessTokenInterface::class, FluentAccessToken::class);
-        $app->bind(RefreshTokenInterface::class, FluentRefreshToken::class);
+        $this->app->bind(ClientInterface::class, FluentClient::class);
+        $this->app->bind(ScopeInterface::class, FluentScope::class);
+        $this->app->bind(SessionInterface::class, FluentSession::class);
+        $this->app->bind(AuthCodeInterface::class, FluentAuthCode::class);
+        $this->app->bind(AccessTokenInterface::class, FluentAccessToken::class);
+        $this->app->bind(RefreshTokenInterface::class, FluentRefreshToken::class);
     }
 
     /**


### PR DESCRIPTION
The problem is that in Lumen 5.2 (for some reason) ``Laravel\Lumen\Application`` no longer implements ``\Illuminate\Contracts\Foundation\Application``.

This causes the providers ``LucaDegasperi\OAuth2Server\OAuth2ServerServiceProvider`` and ``LucaDegasperi\OAuth2Server\Storage\FluentStorageServiceProvider`` to fail, since they expect the ``$app`` to implement that contract.

In this PR the type hint ``$app`` var is removed from several functions in the providers and use ``$this->app`` instead, as that is the most common usage.