### PR TITLE
Type-hint on container instead of Application

### DIFF
--- a/src/Storage/FluentStorageServiceProvider.php
+++ b/src/Storage/FluentStorageServiceProvider.php
@@ -11,7 +11,7 @@
 
 namespace LucaDegasperi\OAuth2Server\Storage;
 
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Container\Container as Application;
 use Illuminate\Support\ServiceProvider;
 use League\OAuth2\Server\Storage\AccessTokenInterface;
 use League\OAuth2\Server\Storage\AuthCodeInterface;

--- a/tests/functional/bootstrap/FeatureContext.php
+++ b/tests/functional/bootstrap/FeatureContext.php
@@ -127,7 +127,7 @@ class FeatureContext extends BehatFeatureContext
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  \Illuminate\Contracts\Container\Container $app
      *
      * @return void
      */


### PR DESCRIPTION
This fixes some type-hinting that was forgotten in PR #646, and should fix Lumen 5.2 support