### PR TITLE
[Feature Request] Using softDeletes for Session/Token revocation

### DIFF
--- a/database/migrations/2014_04_24_111002_create_oauth_sessions_table.php
+++ b/database/migrations/2014_04_24_111002_create_oauth_sessions_table.php
@@ -33,6 +33,7 @@ class CreateOauthSessionsTable extends Migration
             $table->enum('owner_type', ['client', 'user'])->default('user');
             $table->string('owner_id');
             $table->string('client_redirect_uri')->nullable();
+            $table->softDeletes();
             $table->timestamps();
 
             $table->index(['client_id', 'owner_type', 'owner_id']);

--- a/database/migrations/2014_04_24_111518_create_oauth_access_tokens_table.php
+++ b/database/migrations/2014_04_24_111518_create_oauth_access_tokens_table.php
@@ -33,6 +33,7 @@ class CreateOauthAccessTokensTable extends Migration
             $table->integer('expire_time');
 
             $table->timestamps();
+            $table->softDeletes();
 
             $table->unique(['id', 'session_id']);
             $table->index('session_id');

--- a/src/Storage/FluentAccessToken.php
+++ b/src/Storage/FluentAccessToken.php
@@ -34,7 +34,7 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
     {
         $result = $this->getConnection()->table('oauth_access_tokens')
                 ->where('oauth_access_tokens.id', $token)
-                ->where('deleted_at', NULL)
+                ->where('deleted_at', null)
                 ->first();
 
         if (is_null($result)) {
@@ -78,7 +78,7 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
                 ->select('oauth_scopes.*')
                 ->join('oauth_scopes', 'oauth_access_token_scopes.scope_id', '=', 'oauth_scopes.id')
                 ->where('oauth_access_token_scopes.access_token_id', $token->getId())
-                ->where('deleted_at', NULL)
+                ->where('deleted_at', null)
                 ->get();
 
         $scopes = [];

--- a/src/Storage/FluentAccessToken.php
+++ b/src/Storage/FluentAccessToken.php
@@ -34,6 +34,7 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
     {
         $result = $this->getConnection()->table('oauth_access_tokens')
                 ->where('oauth_access_tokens.id', $token)
+                ->where('deleted_at', NULL)
                 ->first();
 
         if (is_null($result)) {
@@ -77,6 +78,7 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
                 ->select('oauth_scopes.*')
                 ->join('oauth_scopes', 'oauth_access_token_scopes.scope_id', '=', 'oauth_scopes.id')
                 ->where('oauth_access_token_scopes.access_token_id', $token->getId())
+                ->where('deleted_at', NULL)
                 ->get();
 
         $scopes = [];

--- a/src/Storage/FluentAccessToken.php
+++ b/src/Storage/FluentAccessToken.php
@@ -34,7 +34,7 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
     {
         $result = $this->getConnection()->table('oauth_access_tokens')
                 ->where('oauth_access_tokens.id', $token)
-                ->where('deleted_at', null)
+                ->where('oauth_access_tokens.deleted_at', null)
                 ->first();
 
         if (is_null($result)) {
@@ -78,7 +78,6 @@ class FluentAccessToken extends AbstractFluentAdapter implements AccessTokenInte
                 ->select('oauth_scopes.*')
                 ->join('oauth_scopes', 'oauth_access_token_scopes.scope_id', '=', 'oauth_scopes.id')
                 ->where('oauth_access_token_scopes.access_token_id', $token->getId())
-                ->where('deleted_at', null)
                 ->get();
 
         $scopes = [];

--- a/src/Storage/FluentSession.php
+++ b/src/Storage/FluentSession.php
@@ -59,9 +59,10 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
     {
         $result = $this->getConnection()->table('oauth_sessions')
                 ->select('oauth_sessions.*')
+                ->where('oauth_sessions.deleted_at', null)
                 ->join('oauth_access_tokens', 'oauth_sessions.id', '=', 'oauth_access_tokens.session_id')
                 ->where('oauth_access_tokens.id', $accessToken->getId())
-                ->where('deleted_at', null)
+                ->where('oauth_access_tokens.deleted_at', null)
                 ->first();
 
         if (is_null($result)) {
@@ -152,9 +153,9 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
     {
         $result = $this->getConnection()->table('oauth_sessions')
             ->select('oauth_sessions.*')
-            ->where('deleted_at', null)
             ->join('oauth_auth_codes', 'oauth_sessions.id', '=', 'oauth_auth_codes.session_id')
             ->where('oauth_auth_codes.id', $authCode->getId())
+            ->where('oauth_sessions.deleted_at', null)
             ->first();
 
         if (is_null($result)) {

--- a/src/Storage/FluentSession.php
+++ b/src/Storage/FluentSession.php
@@ -36,6 +36,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
     {
         $result = $this->getConnection()->table('oauth_sessions')
                     ->where('oauth_sessions.id', $sessionId)
+                    ->where('deleted_at', NULL)
                     ->first();
 
         if (is_null($result)) {
@@ -60,6 +61,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
                 ->select('oauth_sessions.*')
                 ->join('oauth_access_tokens', 'oauth_sessions.id', '=', 'oauth_access_tokens.session_id')
                 ->where('oauth_access_tokens.id', $accessToken->getId())
+                ->where('deleted_at', NULL)
                 ->first();
 
         if (is_null($result)) {
@@ -150,6 +152,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
     {
         $result = $this->getConnection()->table('oauth_sessions')
             ->select('oauth_sessions.*')
+            ->where('deleted_at', NULL)
             ->join('oauth_auth_codes', 'oauth_sessions.id', '=', 'oauth_auth_codes.session_id')
             ->where('oauth_auth_codes.id', $authCode->getId())
             ->first();

--- a/src/Storage/FluentSession.php
+++ b/src/Storage/FluentSession.php
@@ -36,7 +36,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
     {
         $result = $this->getConnection()->table('oauth_sessions')
                     ->where('oauth_sessions.id', $sessionId)
-                    ->where('deleted_at', NULL)
+                    ->where('deleted_at', null)
                     ->first();
 
         if (is_null($result)) {
@@ -61,7 +61,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
                 ->select('oauth_sessions.*')
                 ->join('oauth_access_tokens', 'oauth_sessions.id', '=', 'oauth_access_tokens.session_id')
                 ->where('oauth_access_tokens.id', $accessToken->getId())
-                ->where('deleted_at', NULL)
+                ->where('deleted_at', null)
                 ->first();
 
         if (is_null($result)) {
@@ -152,7 +152,7 @@ class FluentSession extends AbstractFluentAdapter implements SessionInterface
     {
         $result = $this->getConnection()->table('oauth_sessions')
             ->select('oauth_sessions.*')
-            ->where('deleted_at', NULL)
+            ->where('deleted_at', null)
             ->join('oauth_auth_codes', 'oauth_sessions.id', '=', 'oauth_auth_codes.session_id')
             ->where('oauth_auth_codes.id', $authCode->getId())
             ->first();


### PR DESCRIPTION
I know this request is incomplete, but I wanted to get the discussion started and see what others think of this feature.  I'm not sure what I'd need to add to the code to make it merge-able for this package, or if we can really just leave it up to people to implement this type of thing themselves.

I think this package (and really the League/OAuth2 package) lacks a clearly defined method of token revocation.  In my application, I would prefer to keep logs of sessions created and tokens issued as opposed to just completely deleting the records.

This pull request includes code I changed to enable me to use softDeletes to invalidate sessions and tokens.

```
...
/* Invalidating all sessions created by a client_id and owner_id (password grant) */

public function getLogout(Request $request)
	{
		$user_id = Authorizer::getResourceOwnerId();
		$client_id = Authorizer::getClientId();

		$sessions = OAuthSession::where('client_id', $client_id)
			->where('owner_id', $user_id)->get();
		foreach($sessions as $session)
		{
			foreach($session->tokens()->get() as $token)
			{
				Cache::forget($token->id);
			}
			$session->tokens()->delete();
			$session->delete();
		}
		return Helper::prettyJson(200, [
			'message'	=> 'You have been logged out.'
		]);
}
...
```