### PR TITLE
Add Authorizer alias to Lumen getting started guide

### DIFF
--- a/docs/getting-started/lumen.md
+++ b/docs/getting-started/lumen.md
@@ -36,6 +36,11 @@ $app->routeMiddleware([
 ]);
 ```
 
+... and Authorizer alias
+```php
+class_alias(\LucaDegasperi\OAuth2Server\Facades\Authorizer::class, 'Authorizer');
+```
+
 ### Copy config
 
 Copy `vendor/lucadegasperi/oauth2-server-laravel/config/oauth2.php` to your own config folder (`config/oauth2.php` in your project root). It has to be the correct config folder as it is registered using `$app->configure()`.


### PR DESCRIPTION
In the Lumen getting started guide, add the class_alias registration for the Authorizer class.