### PR TITLE
Apply explicit type to $result.

### DIFF
--- a/src/Storage/FluentClient.php
+++ b/src/Storage/FluentClient.php
@@ -178,7 +178,6 @@ class FluentClient extends AbstractFluentAdapter implements ClientInterface
     protected function hydrateEntity($result)
     {
         $result = (object) $result;
-        
         $client = new ClientEntity($this->getServer());
         $client->hydrate([
             'id' => $result->id,

--- a/src/Storage/FluentClient.php
+++ b/src/Storage/FluentClient.php
@@ -177,6 +177,8 @@ class FluentClient extends AbstractFluentAdapter implements ClientInterface
      */
     protected function hydrateEntity($result)
     {
+        $result = (object) $result;
+        
         $client = new ClientEntity($this->getServer());
         $client->hydrate([
             'id' => $result->id,


### PR DESCRIPTION
HydrateEntity assumes $result will always be some form of object but it's possible for it to be an array also. I've experienced this when implementing the client_credentials grant. [According to the docs](https://laravel.com/api/5.2/Illuminate/Database/Query/Builder.html#method_first) the return type is 'mixed|Builder'.