### PR TITLE
Fix rethrowing of non OAuthException.

### DIFF
--- a/src/Middleware/OAuthExceptionHandlerMiddleware.php
+++ b/src/Middleware/OAuthExceptionHandlerMiddleware.php
@@ -32,19 +32,19 @@ class OAuthExceptionHandlerMiddleware
      */
     public function handle($request, Closure $next)
     {
-	    $response = $next($request);
+	$response = $next($request);
 
-            // Was an OAuthException previously caught by the pipeline? If so, hijack response, replacing with json error.
-            if (isset($response->exception) && $response->exception instanceof OAuthException) {
+        // Was an OAuthException previously caught by the pipeline? If so, hijack response, replacing with json error.
+        if (isset($response->exception) && $response->exception instanceof OAuthException) {
 
-                $data = [
-                    'error' => $response->exception->errorType,
-                    'error_description' => $response->exception->getMessage(),
-                ];
+            $data = [
+                'error' => $response->exception->errorType,
+                'error_description' => $response->exception->getMessage(),
+            ];
 
-                return new JsonResponse($data, $response->exception->httpStatusCode, $response->exception->getHttpHeaders());
-            }
+            return new JsonResponse($data, $response->exception->httpStatusCode, $response->exception->getHttpHeaders());
+        }
 
-            return $response;
+        return $response;
     }
 }

--- a/src/Middleware/OAuthExceptionHandlerMiddleware.php
+++ b/src/Middleware/OAuthExceptionHandlerMiddleware.php
@@ -32,21 +32,19 @@ class OAuthExceptionHandlerMiddleware
      */
     public function handle($request, Closure $next)
     {
-        try {
-            $response = $next($request);
-            // Was an exception thrown? If so and available catch in our middleware
-            if (isset($response->exception) && $response->exception) {
-                throw $response->exception;
+	    $response = $next($request);
+
+            // Was an OAuthException previously caught by the pipeline? If so, hijack response, replacing with json error.
+            if (isset($response->exception) && $response->exception instanceof OAuthException) {
+
+                $data = [
+                    'error' => $response->exception->errorType,
+                    'error_description' => $response->exception->getMessage(),
+                ];
+
+                return new JsonResponse($data, $response->exception->httpStatusCode, $response->exception->getHttpHeaders());
             }
 
             return $response;
-        } catch (OAuthException $e) {
-            $data = [
-                'error' => $e->errorType,
-                'error_description' => $e->getMessage(),
-            ];
-
-            return new JsonResponse($data, $e->httpStatusCode, $e->getHttpHeaders());
-        }
     }
 }

--- a/src/Middleware/OAuthExceptionHandlerMiddleware.php
+++ b/src/Middleware/OAuthExceptionHandlerMiddleware.php
@@ -32,11 +32,10 @@ class OAuthExceptionHandlerMiddleware
      */
     public function handle($request, Closure $next)
     {
-	$response = $next($request);
+        $response = $next($request);
 
         // Was an OAuthException previously caught by the pipeline? If so, hijack response, replacing with json error.
         if (isset($response->exception) && $response->exception instanceof OAuthException) {
-
             $data = [
                 'error' => $response->exception->errorType,
                 'error_description' => $response->exception->getMessage(),


### PR DESCRIPTION
Using OAuthExceptionHandlerMiddleware has unintended consequences when non OAuthException is thrown in the application.

Basically, any exception that has already been caught in the Laravel pipeline gets re-thrown in OAuthExceptionHandlerMiddleware but the middleware only catches OAuthExceptions! The consequence of this is that App\Exceptions\Handler::report() get's called twice because the external Exception was caught by the pipeline 2x.