### PR TITLE
Add Laravel 5.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/database": "5.1.* || 5.2.* || 5.3.*",
-        "illuminate/console": "5.1.* || 5.2.* || 5.3.*",
-        "illuminate/contracts": "5.1.* || 5.2.* || 5.3.*",
-        "illuminate/http": "5.1.* || 5.2.* || 5.3.*",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.*",
-        "illuminate/config": "5.1.* || 5.2.* || 5.3.*",
+        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/console": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/contracts": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/http": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/config": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
         "league/oauth2-server": "4.1.*"
     },
     "require-dev": {


### PR DESCRIPTION
Even though Laravel 5.3+ features Passport, it's still not entirely compatible with Lumen 5.3+. 